### PR TITLE
temporary solution for compiling with xcode 15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,6 @@ include $(THEOS)/makefiles/common.mk
 TWEAK_NAME = YoutubeSpeed
 
 YoutubeSpeed_FILES = Tweak.xm
-YoutubeSpeed_CFLAGS = -fobjc-arc
+YoutubeSpeed_CFLAGS = -fobjc-arc -Wno-module-import-in-extern-c
 
 include $(THEOS_MAKE_PATH)/tweak.mk


### PR DESCRIPTION
Another way is to use the iOS 16.5 SDK specifically. I have no clue which one is better tho.

Ref: https://github.com/theos/theos/issues/791